### PR TITLE
feat: TAL-40 plan page redesign — dark table, real logos, gap timeline

### DIFF
--- a/apps/api/src/db/migrations/017_fix_amazon_logo.sql
+++ b/apps/api/src/db/migrations/017_fix_amazon_logo.sql
@@ -1,0 +1,12 @@
+-- Migration 017: Fix Amazon Prime Video logo path
+-- The old path /emthp39XA2YScoYL1p0sdbBSFUK.jpg returns 404 from TMDB.
+-- Use the correct path /pvske1MyAoymrs5bguRfVqYiM9a.jpg (confirmed 200 at w45).
+
+BEGIN;
+
+UPDATE streaming_services
+SET logo_path = '/pvske1MyAoymrs5bguRfVqYiM9a.jpg'
+WHERE tmdb_provider_id = 9
+  AND logo_path = '/emthp39XA2YScoYL1p0sdbBSFUK.jpg';
+
+COMMIT;

--- a/apps/api/src/routes/tmdb.ts
+++ b/apps/api/src/routes/tmdb.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { ValidationError } from '../middleware/errorHandler.js';
 import { tmdbService } from '../services/tmdb.js';
 import { watchlistStorageService } from '../storage/simple-watchlist.js';
+import { serviceSupabase } from '../db/supabase.js';
 // Types are inferred from the API responses, no imports needed from @tally/types for this router
 
 const router: Router = Router();
@@ -97,6 +98,44 @@ router.get('/show/:id/analyze', async (req, res, next) => {
       country,
       analysis,
     });
+
+    // Fire-and-forget: persist episode air dates back to DB so the plan endpoint can use them
+    if (analysis?.diagnostics?.episodeDetails?.length) {
+      const analyzedSeason = analysis.analyzedSeason;
+      setImmediate(async () => {
+        try {
+          // Look up our internal show + season IDs
+          const { data: showRow } = await serviceSupabase
+            .from('shows')
+            .select('id')
+            .eq('tmdb_id', showId)
+            .single();
+          if (!showRow) return;
+
+          const { data: seasonRow } = await serviceSupabase
+            .from('seasons')
+            .select('id')
+            .eq('show_id', showRow.id)
+            .eq('season_number', analyzedSeason)
+            .single();
+          if (!seasonRow) return;
+
+          // Update each episode's air_date (and name if we have it)
+          for (const ep of analysis.diagnostics.episodeDetails) {
+            await serviceSupabase
+              .from('episodes')
+              .update({
+                air_date: ep.airDate ? ep.airDate.slice(0, 10) : null,
+                name: ep.title ?? undefined,
+              })
+              .eq('season_id', seasonRow.id)
+              .eq('episode_number', ep.number);
+          }
+        } catch {
+          // Non-critical — don't let this affect the response
+        }
+      });
+    }
   } catch (error) {
     console.error(`Error analyzing show ${req.params.id}:`, error);
     next(error);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -18,6 +18,7 @@ import {
   asyncHandler,
 } from '../utils/errorHandler.js';
 import { UserService } from '../services/UserService.js';
+import { tmdbService } from '../services/tmdb.js';
 
 const router: Router = Router();
 
@@ -775,13 +776,6 @@ router.post('/:id/subscriptions', authenticateUser, async (req: Request, res: Re
       is_active = true,
     } = req.body;
 
-    if (typeof monthly_cost !== 'number') {
-      return res.status(400).json({
-        success: false,
-        error: 'monthly_cost is required',
-      });
-    }
-
     let service_id = rawServiceId;
 
     // Accept tmdb_provider_id as an alternative — look up the UUID
@@ -795,6 +789,25 @@ router.post('/:id/subscriptions', authenticateUser, async (req: Request, res: Re
         return res.status(404).json({ success: false, error: 'Streaming service not found' });
       }
       service_id = svc.id;
+    }
+
+    // Auto-lookup default price if monthly_cost is 0 or not provided
+    let resolvedCost: number = typeof monthly_cost === 'number' ? monthly_cost : 0;
+    if (resolvedCost === 0 && service_id) {
+      const { data: tierRows } = await serviceSupabase
+        .from('streaming_service_tiers')
+        .select('monthly_price_usd, tier_name, is_default')
+        .eq('service_id', service_id)
+        .order('monthly_price_usd', { ascending: true });
+      if (tierRows && tierRows.length > 0) {
+        // Prefer the default tier, then standard, then lowest price
+        const defaultTier = tierRows.find((p: any) => p.is_default);
+        const standardTier = tierRows.find((p: any) =>
+          (p.tier_name ?? '').toLowerCase().startsWith('standard')
+        );
+        const picked = defaultTier ?? standardTier ?? tierRows[0]!;
+        resolvedCost = picked.monthly_price_usd;
+      }
     }
 
     if (!service_id) {
@@ -817,7 +830,7 @@ router.post('/:id/subscriptions', authenticateUser, async (req: Request, res: Re
       const { data: subscription, error } = await serviceSupabase
         .from('user_streaming_subscriptions')
         .update({
-          monthly_cost,
+          monthly_cost: resolvedCost,
           is_active,
           tier,
           updated_at: new Date().toISOString(),
@@ -844,7 +857,7 @@ router.post('/:id/subscriptions', authenticateUser, async (req: Request, res: Re
       .insert({
         user_id: id,
         service_id,
-        monthly_cost,
+        monthly_cost: resolvedCost,
         tier,
         is_active,
         started_date: new Date().toISOString().split('T')[0],
@@ -978,5 +991,394 @@ router.delete(
     }
   }
 );
+
+/**
+ * GET /api/users/:id/plan
+ * Returns pause recommendations for each active subscription based on the user's
+ * watchlist and upcoming episode air dates.
+ */
+router.get('/:id/plan', authenticateUser, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    if (req.userId !== id) {
+      return res.status(403).json({ success: false, error: 'Forbidden' });
+    }
+
+    // 1. Get user country for TMDB provider lookups
+    const { data: userData } = await serviceSupabase
+      .from('users')
+      .select('country_code')
+      .eq('id', id)
+      .single();
+    const country = ((userData?.country_code as string | null) ?? 'US').toUpperCase();
+
+    // 2. Active subscriptions
+    const { data: subs, error: subsErr } = await serviceSupabase
+      .from('user_streaming_subscriptions')
+      .select(
+        `
+        id,
+        service_id,
+        monthly_cost,
+        streaming_services:service_id (
+          id,
+          tmdb_provider_id,
+          name,
+          logo_path
+        )
+      `
+      )
+      .eq('user_id', id)
+      .eq('is_active', true);
+
+    if (subsErr) throw subsErr;
+    if (!subs || subs.length === 0) {
+      return res.json({ success: true, data: { recommendations: [] } });
+    }
+
+    // Build a set of subscribed tmdb_provider_ids for fast lookup
+    const subsByTmdbId = new Map<number, (typeof subs)[number]>();
+    for (const sub of subs as any[]) {
+      const svc = Array.isArray(sub.streaming_services)
+        ? sub.streaming_services[0]
+        : sub.streaming_services;
+      if (svc?.tmdb_provider_id) {
+        subsByTmdbId.set(svc.tmdb_provider_id, sub);
+      }
+    }
+
+    const BINGE_WATCH_DAYS = 14; // assume a fortnight to watch a binge drop
+
+    // 3. All user shows with show metadata
+    const { data: userShowsRaw } = await serviceSupabase
+      .from('user_shows')
+      .select('id, show_id, selected_service_id, shows:show_id(id, tmdb_id, title, poster_path)')
+      .eq('user_id', id)
+      .in('status', ['watchlist', 'watching']);
+
+    const userShows: Array<{
+      show_id: string;
+      selected_service_id: string | null;
+      tmdb_id: number | null;
+      title: string;
+      poster_path: string | null;
+    }> = (userShowsRaw ?? []).map((r: any) => {
+      const show = Array.isArray(r.shows) ? r.shows[0] : r.shows;
+      return {
+        show_id: r.show_id,
+        selected_service_id: r.selected_service_id ?? null,
+        tmdb_id: show?.tmdb_id ?? null,
+        title: show?.title ?? 'Unknown Show',
+        poster_path: show?.poster_path ?? null,
+      };
+    });
+
+    // 4. Map each show → its subscription service(s)
+    //    a) selected_service_id wins; b) TMDB watch providers as fallback
+    // showsByService: serviceUuid → Set<show_id>
+    const showsByService = new Map<string, Set<string>>();
+
+    for (const us of userShows) {
+      if (us.selected_service_id) {
+        if (!showsByService.has(us.selected_service_id)) {
+          showsByService.set(us.selected_service_id, new Set());
+        }
+        showsByService.get(us.selected_service_id)!.add(us.show_id);
+      } else if (us.tmdb_id && tmdbService.isAvailable) {
+        try {
+          const providers = await tmdbService.getWatchProviders(us.tmdb_id, country);
+          for (const p of providers) {
+            const matchedSub = subsByTmdbId.get(p.provider_id);
+            if (matchedSub) {
+              if (!showsByService.has(matchedSub.service_id)) {
+                showsByService.set(matchedSub.service_id, new Set());
+              }
+              showsByService.get(matchedSub.service_id)!.add(us.show_id);
+            }
+          }
+        } catch {
+          // TMDB lookup failed for this show — skip gracefully
+        }
+      }
+    }
+
+    const now = new Date();
+    const sixMonthsOut = new Date(now.getFullYear(), now.getMonth() + 6, 1);
+
+    type ShowEntry = {
+      title: string;
+      posterPath: string | null;
+      tmdbId: number | null;
+      nextEpisodeName: string | null;
+      nextAirDate: string | null;
+      releasePattern: 'binge' | 'weekly' | 'unknown';
+      // busy window this show occupies on the service
+      busyFrom: Date;
+      busyUntil: Date;
+    };
+
+    const recommendations: Array<{
+      serviceId: string;
+      serviceName: string;
+      monthlyPrice: number;
+      logoPath: string | null;
+      pauseFrom: string | null;
+      pauseUntil: string | null;
+      allGaps: Array<{ from: string; until: string; days: number }>;
+      estimatedSavings: number;
+      whyPause: string | null;
+      whyPauseShow: string | null;
+      whyPauseDate: string | null;
+      reason: string;
+      showCount: number;
+      hasEpisodeData: boolean;
+      upcomingShows: ShowEntry[];
+    }> = [];
+
+    for (const sub of subs as any[]) {
+      const svc = Array.isArray(sub.streaming_services)
+        ? sub.streaming_services[0]
+        : sub.streaming_services;
+
+      const logoPath = svc?.logo_path
+        ? svc.logo_path.startsWith('http')
+          ? svc.logo_path
+          : `https://image.tmdb.org/t/p/w45${svc.logo_path}`
+        : null;
+
+      const showIds = Array.from(showsByService.get(sub.service_id) ?? []);
+
+      if (showIds.length === 0) {
+        const pauseFrom = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+        const pauseUntil = new Date(now.getFullYear(), now.getMonth() + 3, 1);
+        recommendations.push({
+          serviceId: sub.service_id,
+          serviceName: svc?.name ?? sub.service_id,
+          monthlyPrice: sub.monthly_cost,
+          logoPath,
+          pauseFrom: pauseFrom.toISOString(),
+          pauseUntil: pauseUntil.toISOString(),
+          allGaps: [{ from: pauseFrom.toISOString(), until: pauseUntil.toISOString(), days: 60 }],
+          estimatedSavings: parseFloat((sub.monthly_cost * 2).toFixed(2)),
+          whyPause: null,
+          whyPauseShow: null,
+          whyPauseDate: null,
+          reason: 'No shows from your watchlist are on this service.',
+          showCount: 0,
+          hasEpisodeData: false,
+          upcomingShows: [],
+        });
+        continue;
+      }
+
+      // 5. For each show on this service, fetch upcoming episodes grouped by show
+      //    so we can compute per-show busy windows and detect binge vs weekly
+      const upcomingShows: ShowEntry[] = [];
+      // busyIntervals: merged list of [busyFrom, busyUntil] across all shows
+      const busyIntervals: Array<{ from: Date; until: Date }> = [];
+
+      for (const showId of showIds) {
+        const showMeta = userShows.find((u) => u.show_id === showId);
+
+        // Get seasons for this show
+        const { data: seasons } = await serviceSupabase
+          .from('seasons')
+          .select('id, season_number')
+          .eq('show_id', showId);
+
+        const seasonIds = (seasons ?? []).map((s: any) => s.id);
+        if (seasonIds.length === 0) continue;
+
+        // Get upcoming episodes for this show
+        const { data: eps } = await serviceSupabase
+          .from('episodes')
+          .select('air_date, name, episode_number, season_id')
+          .in('season_id', seasonIds)
+          .gte('air_date', now.toISOString().slice(0, 10))
+          .lte('air_date', sixMonthsOut.toISOString().slice(0, 10))
+          .order('air_date', { ascending: true });
+
+        if (!eps || eps.length === 0) continue;
+
+        const episodeDates = eps
+          .map((e: any) => new Date(e.air_date))
+          .filter((d: Date) => !isNaN(d.getTime()));
+        if (episodeDates.length === 0) continue;
+
+        const firstDate = episodeDates[0]!;
+        const lastDate = episodeDates[episodeDates.length - 1]!;
+        const firstEp = eps[0] as any;
+
+        // Detect release pattern: binge if all eps within 2 days, else weekly
+        const spanDays = Math.round(
+          (lastDate.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24)
+        );
+        const isBinge = eps.length > 1 && spanDays <= 2;
+        const releasePattern: 'binge' | 'weekly' = isBinge ? 'binge' : 'weekly';
+
+        // Compute busy window
+        const busyFrom = firstDate;
+        const busyUntil = isBinge
+          ? new Date(firstDate.getTime() + BINGE_WATCH_DAYS * 24 * 60 * 60 * 1000)
+          : lastDate;
+
+        busyIntervals.push({ from: busyFrom, until: busyUntil });
+
+        upcomingShows.push({
+          title: showMeta?.title ?? 'Unknown Show',
+          posterPath: showMeta?.poster_path
+            ? showMeta.poster_path.startsWith('http')
+              ? showMeta.poster_path
+              : `https://image.tmdb.org/t/p/w92${showMeta.poster_path}`
+            : null,
+          tmdbId: showMeta?.tmdb_id ?? null,
+          nextEpisodeName: firstEp.name ?? null,
+          nextAirDate: firstEp.air_date ?? null,
+          releasePattern,
+          busyFrom,
+          busyUntil,
+        });
+      }
+
+      if (upcomingShows.length === 0) {
+        // Shows exist on this service but no upcoming episode data
+        const pauseFrom = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+        const pauseUntil = new Date(now.getFullYear(), now.getMonth() + 3, 1);
+        recommendations.push({
+          serviceId: sub.service_id,
+          serviceName: svc?.name ?? sub.service_id,
+          monthlyPrice: sub.monthly_cost,
+          logoPath,
+          pauseFrom: pauseFrom.toISOString(),
+          pauseUntil: pauseUntil.toISOString(),
+          estimatedSavings: parseFloat((sub.monthly_cost * 2).toFixed(2)),
+          reason: `None of your ${showIds.length} show${showIds.length !== 1 ? 's' : ''} on this service have upcoming episodes in our database yet.`,
+          showCount: showIds.length,
+          hasEpisodeData: false,
+          allGaps: [{ from: pauseFrom.toISOString(), until: pauseUntil.toISOString(), days: 60 }],
+          whyPause: null,
+          whyPauseShow: null,
+          whyPauseDate: null,
+          upcomingShows: [],
+        });
+        continue;
+      }
+
+      // 6. Find ALL gaps in the next 6 months by walking busy intervals
+      busyIntervals.sort((a, b) => a.from.getTime() - b.from.getTime());
+
+      // Merge overlapping busy intervals
+      const merged: Array<{ from: Date; until: Date }> = [];
+      for (const iv of busyIntervals) {
+        const last = merged[merged.length - 1];
+        if (last && iv.from <= last.until) {
+          last.until = iv.until > last.until ? iv.until : last.until;
+        } else {
+          merged.push({ from: iv.from, until: iv.until });
+        }
+      }
+
+      // Walk gaps: [now → first busy], [busy end → next busy], [last busy end → sixMonthsOut]
+      type GapEntry = { from: Date; until: Date; days: number };
+      const allGaps: GapEntry[] = [];
+      let cursor = now;
+
+      for (const iv of merged) {
+        const gapDays = Math.round((iv.from.getTime() - cursor.getTime()) / (1000 * 60 * 60 * 24));
+        if (gapDays >= 1) {
+          allGaps.push({ from: cursor, until: iv.from, days: gapDays });
+        }
+        if (iv.until > cursor) cursor = iv.until;
+      }
+      // Gap after last busy interval
+      const trailingDays = Math.round(
+        (sixMonthsOut.getTime() - cursor.getTime()) / (1000 * 60 * 60 * 24)
+      );
+      if (trailingDays >= 1) {
+        allGaps.push({ from: cursor, until: sixMonthsOut, days: trailingDays });
+      }
+
+      // Primary gap = first gap (most actionable — you can pause right now)
+      const primaryGap = allGaps[0] ?? null;
+
+      if (!primaryGap) {
+        recommendations.push({
+          serviceId: sub.service_id,
+          serviceName: svc?.name ?? sub.service_id,
+          monthlyPrice: sub.monthly_cost,
+          logoPath,
+          pauseFrom: null,
+          pauseUntil: null,
+          allGaps: [],
+          estimatedSavings: 0,
+          whyPause: null,
+          whyPauseShow: null,
+          whyPauseDate: null,
+          reason: `Your shows air back-to-back — no clear pause window in the next 6 months.`,
+          showCount: showIds.length,
+          hasEpisodeData: true,
+          upcomingShows,
+        });
+        continue;
+      }
+
+      // Calculate savings across ALL gaps (total pause-able days)
+      const totalPauseDays = allGaps.reduce((sum, g) => sum + g.days, 0);
+      const totalPauseMonths = totalPauseDays / 30;
+      const savings = parseFloat((sub.monthly_cost * totalPauseMonths).toFixed(2));
+
+      // "Why pause" — what show resumes after the first gap ends
+      const resumeShow = upcomingShows.find(
+        (s) =>
+          new Date(s.busyFrom).getTime() >= primaryGap.until.getTime() - 2 * 24 * 60 * 60 * 1000
+      );
+      const whyPauseDate = resumeShow?.nextAirDate
+        ? new Date(resumeShow.nextAirDate).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          })
+        : resumeShow
+          ? 'soon'
+          : null;
+      const whyPauseShow = resumeShow?.title ?? null;
+      const whyPause = whyPauseShow && whyPauseDate ? `${whyPauseShow} airs ${whyPauseDate}` : null;
+
+      const fmt = (d: Date) =>
+        d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+      recommendations.push({
+        serviceId: sub.service_id,
+        serviceName: svc?.name ?? sub.service_id,
+        monthlyPrice: sub.monthly_cost,
+        logoPath,
+        pauseFrom: primaryGap.from.toISOString(),
+        pauseUntil: primaryGap.until.toISOString(),
+        allGaps: allGaps.map((g) => ({
+          from: g.from.toISOString(),
+          until: g.until.toISOString(),
+          days: g.days,
+        })),
+        estimatedSavings: savings,
+        whyPause,
+        whyPauseShow,
+        whyPauseDate,
+        reason: `Pause from ${fmt(primaryGap.from)} until ${fmt(primaryGap.until)} — nothing from your watchlist airs during this window.`,
+        showCount: showIds.length,
+        hasEpisodeData: true,
+        upcomingShows,
+      });
+    }
+
+    res.json({ success: true, data: { recommendations } });
+  } catch (error) {
+    console.error('Failed to generate plan:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to generate plan',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
 
 export default router;

--- a/apps/web/src/config/api.ts
+++ b/apps/web/src/config/api.ts
@@ -22,6 +22,7 @@ export const API_ENDPOINTS = {
     base: `${API_BASE_URL}/api/users`,
     profile: (userId: string) => `${API_BASE_URL}/api/users/${userId}/profile`,
     subscriptions: (userId: string) => `${API_BASE_URL}/api/users/${userId}/subscriptions`,
+    plan: (userId: string) => `${API_BASE_URL}/api/users/${userId}/plan`,
   },
 
   // Watchlist

--- a/apps/web/src/pages/Plan.tsx
+++ b/apps/web/src/pages/Plan.tsx
@@ -1,174 +1,549 @@
 import React, { useState, useEffect } from 'react';
-import { TrendingDown, Calendar, Bell, Settings } from 'lucide-react';
+import { Settings, ChevronRight } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 import { useAuth } from '../context/AuthContext';
 
-interface Subscription {
-  id: string;
-  serviceId: string;
-  monthlyCost: number;
-  isActive: boolean;
-  service: {
-    id: string;
-    name: string;
-    logoPath: string | null;
-  };
+// Accent: lighter pink-300 per design
+const ACCENT = '#f9a8d4'; // tailwind pink-300
+const ACCENT_DIM = 'rgba(249,168,212,0.50)';
+const TMDB_IMG = (path: string, size = 'w45') => `https://image.tmdb.org/t/p/${size}${path}`;
+
+interface UpcomingShow {
+  title: string;
+  posterPath: string | null;
+  tmdbId: number | null;
+  nextEpisodeName: string | null;
+  nextAirDate: string | null;
+  releasePattern: 'binge' | 'weekly' | 'unknown';
+  busyFrom: string;
+  busyUntil: string;
+}
+
+interface GapEntry {
+  from: string;
+  until: string;
+  days: number;
 }
 
 interface PauseRecommendation {
   serviceId: string;
   serviceName: string;
   monthlyPrice: number;
-  pauseFrom: string;
-  pauseUntil: string;
+  logoPath: string | null;
+  pauseFrom: string | null;
+  pauseUntil: string | null;
+  allGaps: GapEntry[];
   estimatedSavings: number;
+  whyPause: string | null;
+  whyPauseShow: string | null;
+  whyPauseDate: string | null;
   reason: string;
+  showCount: number;
+  hasEpisodeData: boolean;
+  upcomingShows: UpcomingShow[];
 }
 
-const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w92';
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-const formatMonth = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+const fmtShort = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
-const monthsBetween = (from: string, until: string) => {
-  const a = new Date(from);
-  const b = new Date(until);
-  return Math.max(1, (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth()));
-};
+const fmtMonthYear = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 
-// Generate a mock pause recommendation from a subscription while real math isn't wired
-const mockRecommendation = (sub: Subscription): PauseRecommendation => {
-  const now = new Date();
-  const pauseFrom = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-  const pauseUntil = new Date(now.getFullYear(), now.getMonth() + 3, 1);
-  const months = monthsBetween(pauseFrom.toISOString(), pauseUntil.toISOString());
-  return {
-    serviceId: sub.serviceId,
-    serviceName: sub.service.name,
-    monthlyPrice: sub.monthlyCost,
-    pauseFrom: pauseFrom.toISOString(),
-    pauseUntil: pauseUntil.toISOString(),
-    estimatedSavings: parseFloat((sub.monthlyCost * months).toFixed(2)),
-    reason: 'No new episodes of your shows air during this window.',
-  };
-};
+const fmtMonth = (iso: string) => new Date(iso).toLocaleDateString('en-US', { month: 'short' });
 
-const ServiceLogo: React.FC<{ name: string; logoPath: string | null }> = ({ name, logoPath }) => {
-  if (logoPath) {
+const daysBetween = (a: string, b: string) =>
+  Math.round((new Date(b).getTime() - new Date(a).getTime()) / 86_400_000);
+
+// ─── Provider logo — real TMDB image or fallback initial badge ────────────────
+
+const ProviderLogo: React.FC<{ name: string; logoPath: string | null }> = ({ name, logoPath }) => {
+  const [err, setErr] = useState(false);
+  if (logoPath && !err) {
     return (
       <img
-        src={logoPath.startsWith('http') ? logoPath : `${TMDB_IMAGE_BASE}${logoPath}`}
+        src={TMDB_IMG(logoPath, 'w45')}
         alt={name}
-        className="w-10 h-10 rounded-lg object-contain bg-gray-800"
-        onError={(e) => {
-          (e.target as HTMLImageElement).style.display = 'none';
-        }}
+        className="w-9 h-9 rounded-lg object-contain bg-[#1c1c22] flex-shrink-0"
+        onError={() => setErr(true)}
       />
     );
   }
+  // Fallback: coloured initial pill (matches design mockup style)
+  const initials = name.length <= 3 ? name : name.slice(0, 2).toUpperCase();
   return (
-    <div className="w-10 h-10 rounded-lg bg-gray-700 flex items-center justify-center text-xs font-bold text-gray-300">
-      {name.slice(0, 2).toUpperCase()}
+    <div
+      className="w-9 h-9 rounded-lg flex items-center justify-center font-bold text-[11px] flex-shrink-0"
+      style={{
+        background: 'rgba(249,168,212,0.12)',
+        color: ACCENT,
+        border: `1px solid rgba(249,168,212,0.25)`,
+      }}
+    >
+      {initials}
     </div>
   );
 };
 
-const PauseBar: React.FC<{ from: string; until: string }> = ({ from, until }) => {
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  const now = new Date();
-  const fromDate = new Date(from);
-  const untilDate = new Date(until);
+// ─── Show poster thumbnail ────────────────────────────────────────────────────
 
-  const windowMonths = Array.from({ length: 6 }, (_, i) => {
-    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-    const isPause = d >= fromDate && d < untilDate;
-    return { label: months[d.getMonth()], isPause };
+const Poster: React.FC<{ title: string; posterPath: string | null }> = ({ title, posterPath }) => {
+  const [err, setErr] = useState(false);
+  if (posterPath && !err) {
+    return (
+      <img
+        src={TMDB_IMG(posterPath, 'w92')}
+        alt={title}
+        className="w-9 h-[54px] rounded object-cover flex-shrink-0 bg-[#1c1c22]"
+        onError={() => setErr(true)}
+      />
+    );
+  }
+  return (
+    <div className="w-9 h-[54px] rounded flex-shrink-0 bg-[#1c1c22] flex items-center justify-center text-[9px] text-gray-600 font-mono">
+      {title.slice(0, 1)}
+    </div>
+  );
+};
+
+// ─── 12-month bar (J–D squares) ──────────────────────────────────────────────
+
+const MonthBar: React.FC<{ allGaps: GapEntry[]; upcomingShows: UpcomingShow[] }> = ({
+  allGaps,
+  upcomingShows,
+}) => {
+  const now = new Date();
+  const LABELS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
+
+  const months = LABELS.map((label, i) => {
+    const start = new Date(now.getFullYear(), i, 1);
+    const end = new Date(now.getFullYear(), i + 1, 1);
+    const isPast = end <= now;
+    const isGap = allGaps.some((g) => new Date(g.from) < end && new Date(g.until) > start);
+    const isBusy = upcomingShows.some(
+      (s) => new Date(s.busyFrom) < end && new Date(s.busyUntil) > start
+    );
+    return { label, isPast, isGap, isBusy };
   });
 
   return (
-    <div className="flex gap-1 mt-3">
-      {windowMonths.map(({ label, isPause }) => (
-        <div key={label} className="flex-1 text-center">
-          <div className={`h-2 rounded-full mb-1 ${isPause ? 'bg-emerald-500' : 'bg-gray-600'}`} />
-          <span className="text-xs text-gray-500">{label}</span>
+    <div className="flex items-end gap-[3px]">
+      {months.map(({ label, isPast, isGap, isBusy }, i) => (
+        <div key={i} className="flex flex-col items-center gap-0.5">
+          <div
+            style={{
+              width: 10,
+              height: 18,
+              borderRadius: 2,
+              background: isPast
+                ? '#1a1a22'
+                : isGap
+                  ? ACCENT_DIM
+                  : isBusy
+                    ? 'rgba(168,85,247,0.55)'
+                    : '#24242c',
+              border: `1px solid ${isPast ? '#24242c' : isGap ? 'transparent' : isBusy ? 'transparent' : '#2e2e38'}`,
+            }}
+          />
+          <span className="text-[7px] font-mono" style={{ color: '#4a4a58' }}>
+            {label}
+          </span>
         </div>
       ))}
     </div>
   );
 };
 
-const PlanCard: React.FC<{ sub: Subscription; rec: PauseRecommendation }> = ({ sub, rec }) => (
-  <div className="bg-gray-800 border border-gray-700 rounded-xl p-5 space-y-4">
-    {/* Header */}
-    <div className="flex items-center gap-3">
-      <ServiceLogo name={sub.service.name} logoPath={sub.service.logoPath} />
-      <div className="flex-1 min-w-0">
-        <h3 className="font-semibold text-white text-sm">{sub.service.name}</h3>
-        <p className="text-gray-400 text-xs">${sub.monthlyCost.toFixed(2)}/mo</p>
-      </div>
-      <div className="text-right">
-        <p className="text-emerald-400 font-bold text-lg">${rec.estimatedSavings}</p>
-        <p className="text-gray-500 text-xs">potential saving</p>
+// ─── Daily heatmap (WHOOP-style, 26 weeks) ───────────────────────────────────
+
+const DailyHeatmap: React.FC<{ allGaps: GapEntry[]; upcomingShows: UpcomingShow[] }> = ({
+  allGaps,
+  upcomingShows,
+}) => {
+  const now = new Date();
+  const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const WEEK_COUNT = 26;
+
+  const start = new Date(now);
+  const dow = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - dow);
+  start.setHours(0, 0, 0, 0);
+
+  const gapSet = new Set<string>();
+  for (const g of allGaps) {
+    const d = new Date(g.from);
+    d.setHours(0, 0, 0, 0);
+    const end = new Date(g.until);
+    while (d < end) {
+      gapSet.add(d.toISOString().slice(0, 10));
+      d.setDate(d.getDate() + 1);
+    }
+  }
+  const busySet = new Set<string>();
+  for (const s of upcomingShows) {
+    const d = new Date(s.busyFrom);
+    d.setHours(0, 0, 0, 0);
+    const end = new Date(s.busyUntil);
+    while (d < end) {
+      busySet.add(d.toISOString().slice(0, 10));
+      d.setDate(d.getDate() + 1);
+    }
+  }
+
+  const weeks: Array<Array<{ iso: string; isGap: boolean; isBusy: boolean; isPast: boolean }>> = [];
+  const monthHeaders: Array<{ weekIndex: number; label: string }> = [];
+  let lastMonth = -1;
+
+  for (let w = 0; w < WEEK_COUNT; w++) {
+    const week: (typeof weeks)[0] = [];
+    for (let d = 0; d < 7; d++) {
+      const day = new Date(start);
+      day.setDate(day.getDate() + w * 7 + d);
+      const iso = day.toISOString().slice(0, 10);
+      const m = day.getMonth();
+      if (m !== lastMonth) {
+        monthHeaders.push({
+          weekIndex: w,
+          label:
+            ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][
+              m
+            ] ?? '',
+        });
+        lastMonth = m;
+      }
+      week.push({ iso, isGap: gapSet.has(iso), isBusy: busySet.has(iso), isPast: day < now });
+    }
+    weeks.push(week);
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-max">
+        <div className="flex mb-1" style={{ paddingLeft: 20 }}>
+          {weeks.map((_, wi) => {
+            const hdr = monthHeaders.find((h) => h.weekIndex === wi);
+            return (
+              <div key={wi} className="w-4 flex-shrink-0">
+                {hdr && (
+                  <span
+                    className="text-[8px] font-mono whitespace-nowrap"
+                    style={{ color: '#4a4a58' }}
+                  >
+                    {hdr.label}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {DAY_LABELS.map((lbl, di) => (
+          <div key={di} className="flex items-center mb-px">
+            <span
+              className="text-[8px] font-mono w-4 flex-shrink-0 text-right pr-1"
+              style={{ color: '#4a4a58' }}
+            >
+              {di % 2 === 0 ? lbl : ''}
+            </span>
+            {weeks.map((week, wi) => {
+              const cell = week[di];
+              if (!cell) return <div key={wi} className="w-4 h-3 flex-shrink-0" />;
+              return (
+                <div
+                  key={wi}
+                  className="w-3 h-3 flex-shrink-0 rounded-[2px] mx-px"
+                  style={{
+                    background: cell.isPast
+                      ? '#1a1a22'
+                      : cell.isGap
+                        ? ACCENT_DIM
+                        : cell.isBusy
+                          ? 'rgba(168,85,247,0.55)'
+                          : '#24242c',
+                  }}
+                  title={cell.iso}
+                />
+              );
+            })}
+          </div>
+        ))}
+        <div className="flex items-center gap-4 mt-2 pl-5">
+          {[
+            { color: ACCENT_DIM, label: 'Pause' },
+            { color: 'rgba(168,85,247,0.55)', label: 'Watching' },
+            { color: '#24242c', label: 'Inactive' },
+          ].map(({ color, label }) => (
+            <div key={label} className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded-[2px]" style={{ background: color }} />
+              <span className="text-[9px] font-mono" style={{ color: '#6b6a68' }}>
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
+  );
+};
 
-    {/* Recommendation */}
-    <div className="bg-gray-700/50 rounded-lg px-4 py-3 flex items-start gap-3">
-      <TrendingDown className="w-4 h-4 text-emerald-400 mt-0.5 shrink-0" />
-      <div>
-        <p className="text-sm text-white font-medium">
-          Pause {formatMonth(rec.pauseFrom)} – {formatMonth(rec.pauseUntil)}
+// ─── Expanded row detail ──────────────────────────────────────────────────────
+
+const RowDetail: React.FC<{
+  rec: PauseRecommendation;
+  viewMode: 'month' | 'day';
+  onToggleView: () => void;
+}> = ({ rec, viewMode, onToggleView }) => (
+  <div
+    className="px-6 py-5 space-y-4"
+    style={{ background: 'rgba(0,0,0,0.25)', borderTop: '1px solid rgba(255,255,255,0.04)' }}
+  >
+    {/* Timeline toggle header */}
+    <div className="flex items-center justify-between">
+      <span
+        className="text-[10px] font-mono uppercase tracking-[0.12em]"
+        style={{ color: '#6b6a68' }}
+      >
+        Gap timeline
+      </span>
+      <button
+        onClick={onToggleView}
+        className="text-[10px] font-mono px-2 py-0.5 rounded transition-colors"
+        style={{
+          color: '#a5a3a0',
+          border: '1px solid #2e2e38',
+          background: 'transparent',
+        }}
+        onMouseEnter={(e) => ((e.target as HTMLButtonElement).style.color = '#f4f3ef')}
+        onMouseLeave={(e) => ((e.target as HTMLButtonElement).style.color = '#a5a3a0')}
+      >
+        {viewMode === 'month' ? 'Daily view' : 'Month view'}
+      </button>
+    </div>
+
+    {viewMode === 'month' ? (
+      <MonthBar allGaps={rec.allGaps} upcomingShows={rec.upcomingShows} />
+    ) : (
+      <DailyHeatmap allGaps={rec.allGaps} upcomingShows={rec.upcomingShows} />
+    )}
+
+    {/* Why pause / back on */}
+    {rec.whyPause && (
+      <p className="text-xs font-mono" style={{ color: '#6b6a68' }}>
+        Resume when <span style={{ color: '#a5a3a0' }}>{rec.whyPause}</span>
+      </p>
+    )}
+
+    {/* All gaps */}
+    {rec.allGaps.length > 1 && (
+      <div className="space-y-1">
+        <p
+          className="text-[10px] font-mono uppercase tracking-[0.12em] mb-2"
+          style={{ color: '#4a4a58' }}
+        >
+          All pause windows
         </p>
-        <p className="text-xs text-gray-400 mt-0.5">{rec.reason}</p>
+        {rec.allGaps.map((g, i) => (
+          <div key={i} className="flex items-center justify-between">
+            <span className="text-xs font-mono" style={{ color: '#a5a3a0' }}>
+              {fmtShort(g.from)} – {fmtShort(g.until)}
+            </span>
+            <span className="text-xs font-mono" style={{ color: '#6b6a68' }}>
+              {g.days}d
+            </span>
+          </div>
+        ))}
       </div>
-    </div>
+    )}
 
-    {/* Timeline bar */}
-    <div>
-      <div className="flex items-center gap-1.5 mb-1">
-        <Calendar className="w-3 h-3 text-gray-500" />
-        <span className="text-xs text-gray-500 uppercase tracking-wide">Next 6 months</span>
+    {/* Upcoming shows with real posters */}
+    {rec.upcomingShows.length > 0 && (
+      <div className="space-y-2.5">
+        <p
+          className="text-[10px] font-mono uppercase tracking-[0.12em]"
+          style={{ color: '#4a4a58' }}
+        >
+          Shows on this service
+        </p>
+        {rec.upcomingShows.map((show, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Poster title={show.title} posterPath={show.posterPath} />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5 mb-0.5">
+                <p className="text-sm font-medium truncate" style={{ color: '#f4f3ef' }}>
+                  {show.title}
+                </p>
+                {show.releasePattern !== 'unknown' && (
+                  <span
+                    className="text-[9px] font-mono px-1.5 py-px rounded flex-shrink-0"
+                    style={
+                      show.releasePattern === 'binge'
+                        ? { background: 'rgba(168,85,247,0.2)', color: '#c084fc' }
+                        : { background: 'rgba(59,130,246,0.2)', color: '#93c5fd' }
+                    }
+                  >
+                    {show.releasePattern}
+                  </span>
+                )}
+              </div>
+              {show.nextEpisodeName && (
+                <p className="text-xs font-mono truncate" style={{ color: '#6b6a68' }}>
+                  Next: {show.nextEpisodeName}
+                </p>
+              )}
+            </div>
+            <div className="text-right flex-shrink-0">
+              {show.nextAirDate && (
+                <p className="text-xs font-mono font-medium" style={{ color: ACCENT }}>
+                  {fmtShort(show.nextAirDate)}
+                </p>
+              )}
+              {show.releasePattern === 'binge' && (
+                <p className="text-[9px] font-mono" style={{ color: '#4a4a58' }}>
+                  +14d watch
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
       </div>
-      <PauseBar from={rec.pauseFrom} until={rec.pauseUntil} />
-      <div className="flex items-center gap-3 mt-2">
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-emerald-500" />
-          <span className="text-xs text-gray-400">Pause window</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-gray-600" />
-          <span className="text-xs text-gray-400">Active</span>
-        </div>
-      </div>
-    </div>
-
-    {/* Action */}
-    <button
-      className="w-full flex items-center justify-center gap-2 text-xs text-gray-400 border border-gray-600 rounded-lg py-2 hover:border-gray-500 hover:text-gray-300 transition-colors"
-      onClick={() => {}}
-    >
-      <Bell className="w-3.5 h-3.5" />
-      Set a reminder
-    </button>
+    )}
   </div>
 );
 
+// ─── Table row ────────────────────────────────────────────────────────────────
+
+const PlanRow: React.FC<{ rec: PauseRecommendation }> = ({ rec }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [viewMode, setViewMode] = useState<'month' | 'day'>('month');
+  const hasPause = rec.pauseFrom && rec.pauseUntil;
+
+  const showCount = rec.showCount || rec.upcomingShows.length;
+  const showCountLabel =
+    showCount === 0 ? 'nothing you track' : `${showCount} show${showCount !== 1 ? 's' : ''}`;
+
+  // Window: "Jun — Aug" with month count below
+  const windowLabel = hasPause ? `${fmtMonth(rec.pauseFrom!)} — ${fmtMonth(rec.pauseUntil!)}` : '—';
+  const pauseDays = hasPause ? daysBetween(rec.pauseFrom!, rec.pauseUntil!) : 0;
+  const pauseMonthsLabel =
+    pauseDays >= 28 ? `${Math.round(pauseDays / 30)}mo` : pauseDays > 0 ? `${pauseDays}d` : '';
+
+  // "Why pause" reason line
+  const whyPauseShort =
+    rec.upcomingShows.length === 0
+      ? 'No tracked shows airing'
+      : rec.upcomingShows.length === 1
+        ? `Between airings${rec.upcomingShows[0]?.releasePattern === 'binge' ? ' (binge)' : ''}`
+        : 'Between seasons';
+
+  // "back Jun 25 · Avatar..." second line
+  const backLine =
+    rec.whyPauseDate && rec.whyPauseShow
+      ? `back ${rec.whyPauseDate} · ${rec.whyPauseShow}`
+      : rec.whyPause
+        ? `back ${rec.whyPause}`
+        : null;
+
+  return (
+    <>
+      <tr
+        onClick={() => setExpanded((v) => !v)}
+        className="cursor-pointer transition-colors"
+        style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}
+        onMouseEnter={(e) =>
+          ((e.currentTarget as HTMLTableRowElement).style.background = 'rgba(255,255,255,0.02)')
+        }
+        onMouseLeave={(e) =>
+          ((e.currentTarget as HTMLTableRowElement).style.background = 'transparent')
+        }
+      >
+        {/* PROVIDER */}
+        <td className="py-4 pr-4" style={{ paddingLeft: 0 }}>
+          <div className="flex items-center gap-3">
+            <ProviderLogo name={rec.serviceName} logoPath={rec.logoPath} />
+            <div className="min-w-0">
+              <p className="text-sm font-semibold" style={{ color: '#f4f3ef' }}>
+                {rec.serviceName}
+              </p>
+              <p
+                className="text-[11px] font-mono truncate max-w-[140px]"
+                style={{ color: '#4a4a58' }}
+              >
+                {showCountLabel}
+              </p>
+            </div>
+          </div>
+        </td>
+
+        {/* WHY PAUSE */}
+        <td className="py-4 px-4">
+          <p className="text-sm" style={{ color: '#a5a3a0' }}>
+            {whyPauseShort}
+          </p>
+          {backLine && (
+            <p
+              className="text-[11px] font-mono mt-0.5 truncate max-w-[220px]"
+              style={{ color: '#4a4a58' }}
+            >
+              {backLine}
+            </p>
+          )}
+        </td>
+
+        {/* GAP TIMELINE */}
+        <td className="py-4 px-4">
+          <MonthBar allGaps={rec.allGaps} upcomingShows={rec.upcomingShows} />
+        </td>
+
+        {/* WINDOW */}
+        <td className="py-4 px-4 text-right">
+          <p className="text-sm font-mono whitespace-nowrap" style={{ color: '#f4f3ef' }}>
+            {windowLabel}
+          </p>
+          {pauseMonthsLabel && (
+            <p className="text-[11px] font-mono" style={{ color: '#4a4a58' }}>
+              {pauseMonthsLabel}
+            </p>
+          )}
+        </td>
+
+        {/* SAVE */}
+        <td className="py-4 text-right whitespace-nowrap" style={{ paddingRight: 0 }}>
+          <span
+            className="text-sm font-mono font-semibold"
+            style={{ color: rec.estimatedSavings > 0 ? ACCENT : '#4a4a58' }}
+          >
+            {rec.estimatedSavings > 0 ? `+$${rec.estimatedSavings.toFixed(2)}` : '—'}
+          </span>
+          <ChevronRight
+            className="inline-block ml-1 w-3 h-3 transition-transform"
+            style={{
+              color: '#4a4a58',
+              transform: expanded ? 'rotate(90deg)' : 'none',
+            }}
+          />
+        </td>
+      </tr>
+
+      {expanded && (
+        <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+          <td colSpan={5} className="p-0">
+            <RowDetail
+              rec={rec}
+              viewMode={viewMode}
+              onToggleView={() => setViewMode((v) => (v === 'month' ? 'day' : 'month'))}
+            />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+};
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
 const Plan: React.FC = () => {
   const { user } = useAuth();
-  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [recommendations, setRecommendations] = useState<PauseRecommendation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -177,21 +552,34 @@ const Plan: React.FC = () => {
     const load = async () => {
       try {
         setLoading(true);
-        const result = await apiRequest(API_ENDPOINTS.users.subscriptions(user.id));
-        const subs: Subscription[] = (result.data?.subscriptions ?? [])
-          .filter((s: any) => s.is_active)
-          .map((s: any) => ({
-            id: s.id,
-            serviceId: s.service_id,
-            monthlyCost: s.monthly_cost,
-            isActive: s.is_active,
-            service: {
-              id: s.service?.id ?? s.service_id,
-              name: s.service?.name ?? s.service_id,
-              logoPath: s.service?.logo_path ?? null,
-            },
-          }));
-        setSubscriptions(subs);
+        const result = await apiRequest(API_ENDPOINTS.users.plan(user.id));
+        const recs: PauseRecommendation[] = (result.data?.recommendations ?? []).map((r: any) => ({
+          serviceId: r.serviceId,
+          serviceName: r.serviceName,
+          monthlyPrice: r.monthlyPrice,
+          logoPath: r.logoPath ?? null,
+          pauseFrom: r.pauseFrom ?? null,
+          pauseUntil: r.pauseUntil ?? null,
+          allGaps: r.allGaps ?? [],
+          estimatedSavings: r.estimatedSavings,
+          whyPause: r.whyPause ?? null,
+          whyPauseShow: r.whyPauseShow ?? null,
+          whyPauseDate: r.whyPauseDate ?? null,
+          reason: r.reason,
+          showCount: r.showCount ?? 0,
+          hasEpisodeData: r.hasEpisodeData ?? false,
+          upcomingShows: (r.upcomingShows ?? []).map((s: any) => ({
+            title: s.title,
+            posterPath: s.posterPath ?? null,
+            tmdbId: s.tmdbId ?? null,
+            nextEpisodeName: s.nextEpisodeName ?? null,
+            nextAirDate: s.nextAirDate ?? null,
+            releasePattern: s.releasePattern ?? 'unknown',
+            busyFrom: s.busyFrom,
+            busyUntil: s.busyUntil,
+          })),
+        }));
+        setRecommendations(recs);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load plan');
       } finally {
@@ -204,22 +592,31 @@ const Plan: React.FC = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        <div
+          className="animate-spin rounded-full h-8 w-8 border-b-2"
+          style={{ borderColor: ACCENT }}
+        />
       </div>
     );
   }
 
   if (error) {
-    return <div className="p-6 text-center text-red-400 text-sm">{error}</div>;
+    return (
+      <div className="p-6 text-center text-sm" style={{ color: '#f87171' }}>
+        {error}
+      </div>
+    );
   }
 
-  if (subscriptions.length === 0) {
+  if (recommendations.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-4 text-center px-6">
-        <Settings className="w-10 h-10 text-gray-600" />
+        <Settings className="w-10 h-10" style={{ color: '#2e2e38' }} />
         <div>
-          <p className="text-white font-medium">No subscriptions yet</p>
-          <p className="text-gray-400 text-sm mt-1">
+          <p className="font-semibold" style={{ color: '#f4f3ef' }}>
+            No subscriptions yet
+          </p>
+          <p className="text-sm mt-1" style={{ color: '#6b6a68' }}>
             Add your subscriptions in Settings to see your pause plan.
           </p>
         </div>
@@ -227,42 +624,214 @@ const Plan: React.FC = () => {
     );
   }
 
-  const totalMonthly = subscriptions.reduce((sum, s) => sum + s.monthlyCost, 0);
-  const recommendations = subscriptions.map(mockRecommendation);
+  const totalMonthly = recommendations.reduce((sum, r) => sum + r.monthlyPrice, 0);
   const totalSavings = recommendations.reduce((sum, r) => sum + r.estimatedSavings, 0);
+  const gapsCount = recommendations.filter((r) => r.pauseFrom).length;
+  const trackingCount = recommendations.reduce((sum, r) => sum + r.upcomingShows.length, 0);
+  const airingNow = recommendations.reduce(
+    (sum, r) =>
+      sum +
+      r.upcomingShows.filter((s) => {
+        const now = new Date();
+        return new Date(s.busyFrom) <= now && new Date(s.busyUntil) >= now;
+      }).length,
+    0
+  );
+
+  const firstGap = recommendations.find((r) => r.pauseFrom);
+  const lastGap = [...recommendations].reverse().find((r) => r.pauseUntil);
+  const savingsRange =
+    firstGap && lastGap
+      ? `${fmtMonthYear(firstGap.pauseFrom!)} — ${fmtMonthYear(lastGap.pauseUntil!)}`
+      : '';
+
+  const now = new Date();
+  const seasonLabel = (() => {
+    const m = now.getMonth();
+    if (m >= 2 && m <= 4) return 'Spring';
+    if (m >= 5 && m <= 7) return 'Summer';
+    if (m >= 8 && m <= 10) return 'Autumn';
+    return 'Winter';
+  })();
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
-      {/* Summary header */}
-      <div className="bg-gray-800 border border-gray-700 rounded-xl p-5">
-        <p className="text-gray-400 text-sm">You're paying</p>
-        <p className="text-3xl font-bold text-white mt-1">
-          ${totalMonthly.toFixed(2)}
-          <span className="text-base font-normal text-gray-400">/mo</span>
-        </p>
-        <p className="text-gray-400 text-sm mt-1">
-          across {subscriptions.length} service{subscriptions.length !== 1 ? 's' : ''}
-        </p>
-        {totalSavings > 0 && (
-          <div className="mt-3 flex items-center gap-2 text-emerald-400 text-sm font-medium">
-            <TrendingDown className="w-4 h-4" />
-            Pause smartly and save up to ${totalSavings.toFixed(0)} this year
+    <div className="min-h-screen" style={{ background: '#0a0a0c', color: '#f4f3ef' }}>
+      <div className="max-w-5xl mx-auto px-5 py-8 space-y-6">
+        {/* ── Header label ──────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between">
+          <p
+            className="text-[11px] font-mono uppercase tracking-[0.12em]"
+            style={{ color: '#6b6a68' }}
+          >
+            Your plan · {seasonLabel} {now.getFullYear()}
+          </p>
+          <p className="text-[11px] font-mono" style={{ color: '#4a4a58' }}>
+            Updated just now
+          </p>
+        </div>
+
+        {/* ── Stats card ────────────────────────────────────────────────── */}
+        <div
+          className="rounded-3xl overflow-hidden"
+          style={{
+            background: 'linear-gradient(180deg, #15151a, #101013)',
+            border: '1px solid #24242c',
+          }}
+        >
+          {/* Stat strip — 4 cells */}
+          <div
+            className="grid grid-cols-2 md:grid-cols-4"
+            style={{ borderBottom: '1px solid #24242c' }}
+          >
+            {/* Gaps identified */}
+            <div
+              className="p-5 md:p-7"
+              style={{ borderRight: '1px solid #24242c', borderBottom: undefined }}
+            >
+              <p
+                className="text-[10px] font-mono uppercase tracking-[0.12em] mb-2"
+                style={{ color: '#6b6a68' }}
+              >
+                Gaps identified
+              </p>
+              <p
+                className="text-[52px] leading-none tracking-[-0.02em]"
+                style={{ fontFamily: 'Georgia, serif', color: '#f4f3ef' }}
+              >
+                {gapsCount}
+              </p>
+              <p className="text-[11px] font-mono mt-2" style={{ color: '#4a4a58' }}>
+                across {recommendations.length} provider{recommendations.length !== 1 ? 's' : ''}
+              </p>
+            </div>
+
+            {/* Saving potential — accent highlighted */}
+            <div
+              className="p-5 md:p-7 relative"
+              style={{
+                borderRight: '1px solid #24242c',
+                background: `radial-gradient(80% 120% at 100% 0%, rgba(249,168,212,0.12), transparent 60%)`,
+              }}
+            >
+              <p
+                className="text-[10px] font-mono uppercase tracking-[0.12em] mb-2"
+                style={{ color: ACCENT }}
+              >
+                Saving potential
+              </p>
+              <p
+                className="text-[52px] leading-none tracking-[-0.02em]"
+                style={{ fontFamily: 'Georgia, serif', color: ACCENT }}
+              >
+                ${totalSavings.toFixed(2)}
+              </p>
+              <p className="text-[11px] font-mono mt-2" style={{ color: '#4a4a58' }}>
+                {savingsRange}
+              </p>
+            </div>
+
+            {/* Active */}
+            <div className="p-5 md:p-7" style={{ borderRight: '1px solid #24242c' }}>
+              <p
+                className="text-[10px] font-mono uppercase tracking-[0.12em] mb-2"
+                style={{ color: '#6b6a68' }}
+              >
+                Active
+              </p>
+              <p
+                className="text-[52px] leading-none tracking-[-0.02em]"
+                style={{ fontFamily: 'Georgia, serif', color: '#f4f3ef' }}
+              >
+                {recommendations.length}
+              </p>
+              <p className="text-[11px] font-mono mt-2" style={{ color: '#4a4a58' }}>
+                subscriptions · ${totalMonthly.toFixed(0)}/mo
+              </p>
+            </div>
+
+            {/* Tracking — accent glow top-right */}
+            <div
+              className="p-5 md:p-7 relative"
+              style={{
+                background: `radial-gradient(60% 80% at 90% 10%, rgba(249,168,212,0.10), transparent 70%)`,
+              }}
+            >
+              <p
+                className="text-[10px] font-mono uppercase tracking-[0.12em] mb-2"
+                style={{ color: '#6b6a68' }}
+              >
+                Tracking
+              </p>
+              <p
+                className="text-[52px] leading-none tracking-[-0.02em]"
+                style={{ fontFamily: 'Georgia, serif', color: '#f4f3ef' }}
+              >
+                {trackingCount}
+              </p>
+              <p className="text-[11px] font-mono mt-2" style={{ color: '#4a4a58' }}>
+                shows{airingNow > 0 ? ` · ${airingNow} airing now` : ''}
+              </p>
+            </div>
           </div>
-        )}
-      </div>
 
-      {/* Per-service cards */}
-      <div className="space-y-4">
-        {subscriptions.map((sub, i) => {
-          const rec = recommendations[i];
-          if (!rec) return null;
-          return <PlanCard key={sub.id} sub={sub} rec={rec} />;
-        })}
-      </div>
+          {/* ── Gap table ─────────────────────────────────────────────────── */}
+          <div className="px-5 md:px-6 py-1">
+            <table className="w-full">
+              <thead>
+                <tr style={{ borderBottom: '1px solid #24242c' }}>
+                  {['Provider', 'Why pause', 'Gap timeline', 'Window', 'Save'].map((h, i) => (
+                    <th
+                      key={h}
+                      className={`py-3 text-[10px] font-mono uppercase tracking-[0.1em] font-normal ${i >= 3 ? 'text-right' : 'text-left'}`}
+                      style={{
+                        color: '#4a4a58',
+                        paddingLeft: i === 0 ? 0 : undefined,
+                        paddingRight: i === 4 ? 0 : undefined,
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {recommendations.map((rec) => (
+                  <PlanRow key={rec.serviceId} rec={rec} />
+                ))}
+              </tbody>
+            </table>
+          </div>
 
-      <p className="text-center text-xs text-gray-600 pb-2">
-        Pause recommendations are based on your watchlist activity. Real savings math coming soon.
-      </p>
+          {/* ── Footer ────────────────────────────────────────────────────── */}
+          <div
+            className="px-5 md:px-7 py-4 flex flex-wrap items-center justify-between gap-3"
+            style={{ borderTop: '1px solid #24242c' }}
+          >
+            <p className="text-[12px] font-mono" style={{ color: '#4a4a58' }}>
+              We'll remind you 24h before each pause starts.
+            </p>
+            <div className="flex items-center gap-3">
+              <button
+                className="text-[13px] px-4 h-10 rounded-full transition-colors"
+                style={{ border: '1px solid #2e2e38', color: '#a5a3a0', background: 'transparent' }}
+              >
+                Manage subscriptions
+              </button>
+              <button
+                className="text-[13px] px-5 h-10 rounded-full font-semibold flex items-center gap-2 transition-colors"
+                style={{ background: ACCENT, color: '#0a0a0c' }}
+              >
+                Pause schedule
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-center text-[10px] font-mono pb-2" style={{ color: '#2e2e38' }}>
+          Pause windows based on upcoming episode air dates from your watchlist.
+        </p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **Plan page redesign**: replaced card-based UI with dark cinematic table layout — PROVIDER / WHY PAUSE / GAP TIMELINE / WINDOW / SAVE columns, expandable rows with daily heatmap toggle
- **Real TMDB logos and show posters** in both the table and expanded detail panel
- **`whyPauseShow` / `whyPauseDate`** structured fields on the plan endpoint so the UI formats `back Jun 25 · Avatar...` correctly
- **Episode air date write-back**: analyze route persists TMDB episode dates to DB fire-and-forget, so the plan endpoint picks them up immediately after a user views a show
- **TMDB watch providers fallback**: shows without `selected_service_id` matched to subscriptions via TMDB API
- **Auto-price lookup**: subscription POST handler resolves price from `streaming_service_tiers` when `monthly_cost` is 0
- **Amazon Prime Video logo fix** (migration 017 — apply manually in Supabase SQL editor)
- **Plan2 deprecated**: `Plan2.tsx` removed, `Plan.tsx` is now the single plan page at `/plan`

## Test plan

- [ ] Visit `/plan` — dark table layout with real service logos
- [ ] Expand a row with a tracked show — real poster, `back Jun 25 · Avatar...` in WHY PAUSE
- [ ] Click "Daily view" toggle — WHOOP-style heatmap renders
- [ ] Run migration 017 in Supabase SQL editor to fix Amazon logo
- [ ] `pnpm test` — all 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)